### PR TITLE
Add abort signal, while loops and assignments with operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ npm install topscript
 
 ## Usage
 
-To execute a script, simply do:
+To execute a script, simply do (note that `topscript` is an async function and must be awaited):
 
 ```js
 import { topscript } from 'topscript';
 
-topscript('1 + 2') // => 3;
-topscript('log("hello, world!")', { log: console.log }) // => undefined
+await topscript('1 + 2') // => 3;
+await topscript('log("hello, world!")', { log: console.log }) // => undefined
 
-topscript(`
+await topscript(`
   function add(a, b) {
     return a + b;
   }
@@ -27,7 +27,7 @@ topscript(`
   add(1, 2)
 `) // => 3
 
-topscript('[1, 2, 3].slice(1)') // => [2, 3]
+await topscript('[1, 2, 3].slice(1)') // => [2, 3]
 ```
 
 Topscript also allows to validate a supplied script for parsing errors:
@@ -35,9 +35,47 @@ Topscript also allows to validate a supplied script for parsing errors:
 ```js
 import { validate } from 'topscript';
 
-parse('1 + 2') // => undefined
-parse('1 +') // throws an error
+validate('1 + 2') // => undefined
+validate('1 +') // throws an error
 ```
+
+## Supported Features
+
+Topscript supports a wide range of JavaScript features:
+
+- Variables (const, let)
+- Literals (strings, numbers, booleans, objects, arrays)
+- Functions (declarations, expressions, arrow functions)
+- Control flow (if, else, while)
+- Template literals and string interpolation
+- Closures and nested scopes
+- Compound assignment operators (+=, -=, etc)
+- Basic array and object operations
+- Rest parameters
+
+## Execution Safety Features
+
+Topscript includes several safety mechanisms:
+
+- **Abort Signal Support**: You can abort long-running scripts using an AbortSignal
+  ```js
+  const controller = new AbortController();
+  const scriptPromise = await topscript('while(true) {}', {}, { signal: controller.signal });
+
+  controller.abort(); // Will stop the execution
+  ```
+
+- **Execution Yield**: Long-running scripts periodically yield control back to the event loop to prevent blocking
+
+## Unsupported Features
+
+Some JavaScript features are not supported:
+
+- Async/await functions
+- Optional chaining
+- Destructuring assignments
+- Classes
+- Try/catch blocks
 
 ## Semantic Versioning
 

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -16,96 +16,96 @@ describe('topscript', () => {
   });
 
   describe('topscript', () => {
-    it('evaluates literals', () => {
-      expect(topscript('42')).toBe(42);
-      expect(topscript('"hello"')).toBe('hello');
-      expect(topscript('true')).toBe(true);
-      expect(topscript('false')).toBe(false);
-      expect(topscript('null')).toBe(null);
+    it('evaluates literals', async () => {
+      expect(await topscript('42')).toBe(42);
+      expect(await topscript('"hello"')).toBe('hello');
+      expect(await topscript('true')).toBe(true);
+      expect(await topscript('false')).toBe(false);
+      expect(await topscript('null')).toBe(null);
     });
 
-    it('evaluates binary expressions', () => {
-      expect(topscript('2 + 3')).toBe(5);
-      expect(topscript('5 - 2')).toBe(3);
-      expect(topscript('2 * 3')).toBe(6);
-      expect(topscript('6 / 2')).toBe(3);
-      expect(topscript('7 % 3')).toBe(1);
-      expect(topscript('2 ** 3')).toBe(8);
-      expect(topscript('5 > 3')).toBe(true);
-      expect(topscript('5 < 3')).toBe(false);
-      expect(topscript('5 >= 5')).toBe(true);
-      expect(topscript('5 <= 5')).toBe(true);
-      expect(topscript('5 == 5')).toBe(true);
-      expect(topscript('5 === 5')).toBe(true);
-      expect(topscript('5 != 3')).toBe(true);
-      expect(topscript('5 !== 3')).toBe(true);
+    it('evaluates binary expressions', async () => {
+      expect(await topscript('2 + 3')).toBe(5);
+      expect(await topscript('5 - 2')).toBe(3);
+      expect(await topscript('2 * 3')).toBe(6);
+      expect(await topscript('6 / 2')).toBe(3);
+      expect(await topscript('7 % 3')).toBe(1);
+      expect(await topscript('2 ** 3')).toBe(8);
+      expect(await topscript('5 > 3')).toBe(true);
+      expect(await topscript('5 < 3')).toBe(false);
+      expect(await topscript('5 >= 5')).toBe(true);
+      expect(await topscript('5 <= 5')).toBe(true);
+      expect(await topscript('5 == 5')).toBe(true);
+      expect(await topscript('5 === 5')).toBe(true);
+      expect(await topscript('5 != 3')).toBe(true);
+      expect(await topscript('5 !== 3')).toBe(true);
     });
 
-    it('evaluates logical expressions', () => {
-      expect(topscript('true && true')).toBe(true);
-      expect(topscript('true && false')).toBe(false);
-      expect(topscript('false || true')).toBe(true);
-      expect(topscript('false || false')).toBe(false);
+    it('evaluates logical expressions', async () => {
+      expect(await topscript('true && true')).toBe(true);
+      expect(await topscript('true && false')).toBe(false);
+      expect(await topscript('false || true')).toBe(true);
+      expect(await topscript('false || false')).toBe(false);
     });
 
-    it('evaluates unary expressions', () => {
-      expect(topscript('!true')).toBe(false);
-      expect(topscript('!false')).toBe(true);
-      expect(topscript('-5')).toBe(-5);
-      expect(topscript('+5')).toBe(5);
+    it('evaluates unary expressions', async() => {
+      expect(await topscript('!true')).toBe(false);
+      expect(await topscript('!false')).toBe(true);
+      expect(await topscript('-5')).toBe(-5);
+      expect(await topscript('+5')).toBe(5);
     });
 
-    it('evaluates variable declarations', () => {
-      expect(topscript('const x = 5; x')).toBe(5);
-      expect(topscript('let x = 5; x')).toBe(5);
+    it('evaluates variable declarations', async() => {
+      expect(await topscript('const x = 5; x')).toBe(5);
+      expect(await topscript('let x = 5; x')).toBe(5);
     });
 
-    it('evaluates object assignments', () => {
-      expect(topscript(`
+    it('evaluates object assignments', async() => {
+      expect(await topscript(`
         const obj = {};
         obj.a = 1;
         obj
       `)).toEqual({ a: 1 });
 
-      expect(topscript(`
+      expect(await topscript(`
         const obj = { a: 1 };
         obj.a = 2;
         obj
       `)).toEqual({ a: 2 });
 
-      expect(topscript(`
+      expect(await topscript(`
         const obj = { a: { b: 1 } };
         obj.a.b = 2;
         obj
       `)).toEqual({ a: { b: 2 } });
 
-      expect(topscript(`
+      expect(await topscript(`
         const obj = { a: { bc: 1 } };
         obj.a['b' + 'c'] = 2;
         obj
       `)).toEqual({ a: { bc: 2 } });
     });
 
-    it('evaluates iifs', () => {
-      expect(topscript('(() => 42)()')).toBe(42);
-      expect(topscript('((x) => { return x; })(42)')).toBe(42);
-      expect(topscript('(function(x) { return x; })(42)')).toBe(42);
+    it('evaluates iifs', async() => {
+      expect(await topscript('(() => 42)()')).toBe(42);
+      expect(await topscript('((x) => { return x; })(42)')).toBe(42);
+      expect(await topscript('(function(x) { return x; })(42)')).toBe(42);
     });
 
-    it('evaluates array assignments', () => {
-      expect(topscript(`
+    it('evaluates array assignments', async () => {
+      expect(await topscript(`
         const arr = [1, 2, 3];
         arr[0] = 4;
         arr
       `)).toEqual([4, 2, 3]);
 
-      expect(topscript(`
+      expect(await topscript(`
         const arr = [[1, 2, 3]];
         arr[0][1] = 4;
         arr
       `)).toEqual([[1, 4, 3]]);
 
-      expect(topscript(`
+      expect(await topscript(`
         const arr = [];
         arr[0] = 1;
         arr[1] = 2;
@@ -114,68 +114,68 @@ describe('topscript', () => {
       `)).toEqual([1, 2, 3]);
     });
 
-    it('evaluates arrays', () => {
-      expect(topscript('[1, 2, 3]')).toEqual([1, 2, 3]);
+    it('evaluates arrays', async () => {
+      expect(await topscript('[1, 2, 3]')).toEqual([1, 2, 3]);
 
-      expect(topscript(`
+      expect(await topscript(`
         const x = [1, 2];
         const y = [...x, 3];
         y
       `)).toEqual([1, 2, 3]);
     });
 
-    it('evaluates array access', () => {
-      expect(topscript('[1, 2, 3][0]')).toBe(1);
-      expect(topscript('[1, 2, 3][1]')).toBe(2);
+    it('evaluates array access', async() => {
+      expect(await topscript('[1, 2, 3][0]')).toBe(1);
+      expect(await topscript('[1, 2, 3][1]')).toBe(2);
     });
 
-    it('evaluates string concatenation', () => {
-      expect(topscript('"hello" + " " + "world"')).toBe('hello world');
+    it('evaluates string concatenation', async () => {
+      expect(await topscript('"hello" + " " + "world"')).toBe('hello world');
     });
 
-    it('evaluates string interpolation', () => {
-      expect(topscript('`${"hello"}, ${"world"}`')).toBe('hello, world');
-      expect(topscript('`hello ${1 + 2}`')).toBe('hello 3');
-      expect(topscript('(() => `hello, ${"world"}`)()')).toBe('hello, world');
+    it('evaluates string interpolation', async () => {
+      expect(await topscript('`${"hello"}, ${"world"}`')).toBe('hello, world');
+      expect(await topscript('`hello ${1 + 2}`')).toBe('hello 3');
+      expect(await topscript('(() => `hello, ${"world"}`)()')).toBe('hello, world');
     });
 
-    it('evaluates built-in member functions', () => {
-      expect(topscript('"hello".length')).toBe(5);
-      expect(topscript('"hello".toUpperCase()')).toBe('HELLO');
-      expect(topscript('"hello".indexOf("e")')).toBe(1);
-      expect(topscript('"hello".slice(1, 4)')).toBe('ell');
+    it('evaluates built-in member functions', async () => {
+      expect(await topscript('"hello".length')).toBe(5);
+      expect(await topscript('"hello".toUpperCase()')).toBe('HELLO');
+      expect(await topscript('"hello".indexOf("e")')).toBe(1);
+      expect(await topscript('"hello".slice(1, 4)')).toBe('ell');
     });
 
-    it('evaluates objects', () => {
-      expect(topscript('({ a: 1, b: 2 })')).toEqual({ a: 1, b: 2 });
-      expect(topscript('({ "a": 1, ["b"]: 2, [3]: 4, [`${"c"}`]: 5 })')).toEqual({ a: 1, b: 2, 3: 4, c: 5 });
+    it('evaluates objects', async () => {
+      expect(await topscript('({ a: 1, b: 2 })')).toEqual({ a: 1, b: 2 });
+      expect(await topscript('({ "a": 1, ["b"]: 2, [3]: 4, [`${"c"}`]: 5 })')).toEqual({ a: 1, b: 2, 3: 4, c: 5 });
 
-      expect(topscript(`
+      expect(await topscript(`
         const x = { a: 1 };
         const y = { ...x, b: 2 };
         y
       `)).toEqual({ a: 1, b: 2 });
 
-      expect(topscript('const obj = { a: { b() { return 1; } } }; obj.a.b()')).toBe(1);
+      expect(await topscript('const obj = { a: { b() { return 1; } } }; obj.a.b()')).toBe(1);
     });
 
-    it('does not support optional chaining', () => {
-      expect(() => topscript('({ a: 1 }).b?.c')).toThrow(/Unexpected token/);
+    it('does not support optional chaining', async () => {
+      await expect(() => topscript('({ a: 1 }).b?.c')).rejects.toThrow(/Unexpected token/);
     });
 
-    it('does not support destructuring', () => {
-      expect(() => topscript('const { a } = { a: 1 }; a')).toThrow('Unknown variable declaration ObjectPattern');
+    it('does not support destructuring', async () => {
+      await expect(() => topscript('const { a } = { a: 1 }; a')).rejects.toThrow('Unknown variable declaration ObjectPattern');
     });
 
-    it('allows object property access', () => {
-      expect(topscript('({ a: 1, b: 2 }).a')).toBe(1);
-      expect(topscript('({ a: 1, b: 2 })["a"]')).toBe(1);
-      expect(topscript('({ a: 1, b: 2 }).b')).toBe(2);
-      expect(topscript('({ a: 1, b: 2 })["b"]')).toBe(2);
+    it('allows object property access', async () => {
+      expect(await topscript('({ a: 1, b: 2 }).a')).toBe(1);
+      expect(await topscript('({ a: 1, b: 2 })["a"]')).toBe(1);
+      expect(await topscript('({ a: 1, b: 2 }).b')).toBe(2);
+      expect(await topscript('({ a: 1, b: 2 })["b"]')).toBe(2);
     });
 
-    it('evaluates function declarations', () => {
-      expect(topscript(`
+    it('evaluates function declarations', async () => {
+      expect(await topscript(`
         function add(a, b) {
           return a + b;
         }
@@ -184,15 +184,15 @@ describe('topscript', () => {
       `)).toBe(5);
     });
 
-    it('evaluates arrow functions', () => {
-      expect(topscript(`
+    it('evaluates arrow functions', async () => {
+      expect(await topscript(`
         const add = (a, b) => a + b;
         add(2, 3)
       `)).toBe(5);
     });
 
-    it('evaluates if statements', () => {
-      expect(topscript(`
+    it('evaluates if statements', async () => {
+      expect(await topscript(`
         let x = 0;
 
         if (true) {
@@ -202,7 +202,7 @@ describe('topscript', () => {
         x
       `)).toBe(1);
 
-      expect(topscript(`
+      expect(await topscript(`
         let x = 0;
 
         if (false) {
@@ -214,7 +214,7 @@ describe('topscript', () => {
         x
       `)).toBe(2);
 
-      expect(topscript(`
+      expect(await topscript(`
         let x = 0;
 
         if (false) {
@@ -226,7 +226,7 @@ describe('topscript', () => {
         x
       `)).toBe(2);
 
-      expect(topscript(`
+      expect(await topscript(`
         let x = 0;
 
         if (false) {
@@ -240,17 +240,17 @@ describe('topscript', () => {
         x
       `)).toBe(3);
 
-      expect(topscript('if (true) { 1 } else { 2 }')).toBeUndefined();
-      expect(topscript('if (true) 1')).toBeUndefined();
+      expect(await topscript('if (true) { 1 } else { 2 }')).toBeUndefined();
+      expect(await topscript('if (true) 1')).toBeUndefined();
     });
 
-    it('evaluates with context', () => {
-      expect(topscript('x + 5', { x: 10 })).toBe(15);
-      expect(topscript('greet(name)', { greet: (name: string) => `hello ${name}`, name: 'user' })).toBe('hello user');
+    it('evaluates with context', async () => {
+      expect(await topscript('x + 5', { x: 10 })).toBe(15);
+      expect(await topscript('greet(name)', { greet: (name: string) => `hello ${name}`, name: 'user' })).toBe('hello user');
     });
 
-    it('handles rest parameters', () => {
-      expect(topscript(`
+    it('handles rest parameters', async () => {
+      expect(await topscript(`
         function sum(...nums) {
           return nums.reduce((acc, num) => acc + num, 0);
         }
@@ -259,33 +259,108 @@ describe('topscript', () => {
       `)).toBe(6);
     });
 
-    it('throws on unknown variables', () => {
-      expect(() => topscript('unknownVar')).toThrow('Unknown variable unknownVar');
+    it('throws on unknown variables', async () => {
+      await expect(() => topscript('unknownVar')).rejects.toThrow('Unknown variable unknownVar');
     });
 
-    it('throws on unsupported features', () => {
-      expect(() => topscript('async function f() {}')).toThrow('Async functions are not supported');
-      expect(() => topscript('const f = async () => {}')).toThrow('Async functions are not supported');
+    it('throws on unsupported features', async () => {
+      await expect(() => topscript('async function f() {}')).rejects.toThrow('Async functions are not supported');
+      await expect(() => topscript('const f = async () => {}')).rejects.toThrow('Async functions are not supported');
+    });
+    
+    it('throws when execution exceeds timeout', async () => {
+      await expect(() => 
+        topscript('while(true) {}', {}, { timeout: 100 })
+      ).rejects.toThrow('Execution timed out');
+    });
+    
+    it('evaluates while loops', async () => {
+      expect(await topscript(`
+        let i = 0;
+        let sum = 0;
+        
+        while (i < 5) {
+          sum += i;
+          i += 1;
+        }
+        
+        sum
+      `)).toBe(10);
+      
+      expect(await topscript(`
+        let i = 10;
+        
+        while (i > 0) {
+          i -= 1;
+        }
+        
+        i
+      `)).toBe(0);
+      
+      expect(await topscript(`
+        const arr = [];
+        let i = 0;
+        
+        while (i < 3) {
+          arr.push(i);
+          i += 1;
+        }
+        
+        arr
+      `)).toEqual([0, 1, 2]);
+    });
+    
+    it('evaluates compound assignment operators', async () => {
+      expect(await topscript('let x = 5; x += 3; x')).toBe(8);
+      expect(await topscript('let x = 5; x -= 3; x')).toBe(2);
+      expect(await topscript('let x = 5; x *= 3; x')).toBe(15);
+      expect(await topscript('let x = 6; x /= 3; x')).toBe(2);
+      expect(await topscript('let x = 7; x %= 3; x')).toBe(1);
+      expect(await topscript('let x = 2; x **= 3; x')).toBe(8);
+      
+      expect(await topscript('let x = 5; x &= 3; x')).toBe(1);
+      expect(await topscript('let x = 5; x |= 3; x')).toBe(7);
+      expect(await topscript('let x = 5; x ^= 3; x')).toBe(6);
+      expect(await topscript('let x = 5; x <<= 1; x')).toBe(10);
+      expect(await topscript('let x = 5; x >>= 1; x')).toBe(2);
+      
+      expect(await topscript(`
+        const obj = { a: 5 };
+        obj.a += 3;
+        obj
+      `)).toEqual({ a: 8 });
+      
+      expect(await topscript(`
+        const arr = [1, 2, 3];
+        arr[1] *= 3;
+        arr
+      `)).toEqual([1, 6, 3]);
+      
+      expect(await topscript(`
+        const obj = { value: 5 };
+        obj['value'] += 3;
+        obj
+      `)).toEqual({ value: 8 });
     });
 
     describe('scope', () => {
-      it('creates a new scope for block statements', () => {
-        expect(topscript(`
+      it('creates a new scope for block statements', async () => {
+        expect(await topscript(`
           let x = 1;
           { let x = 2; }
           x
         `)).toBe(1);
       });
 
-      it('supports variable shadowing', () => {
-        expect(topscript(`
+      it('supports variable shadowing', async () => {
+        expect(await topscript(`
           let x = 1;
           { let x = 2; x; }
         `)).toBe(2);
       });
 
-      it('creates new scope for functions', () => {
-        expect(topscript(`
+      it('creates new scope for functions', async () => {
+        expect(await topscript(`
           let x = 1;
 
           function f() {
@@ -297,8 +372,8 @@ describe('topscript', () => {
         `)).toBe(2);
       });
 
-      it('supports accessing parent scope variables', () => {
-        expect(topscript(`
+      it('supports accessing parent scope variables', async () => {
+        expect(await topscript(`
           let x = 1;
 
           function f() {
@@ -309,8 +384,8 @@ describe('topscript', () => {
         `)).toBe(1);
       });
 
-      it('keeps parent scope variables intact', () => {
-        expect(topscript(`
+      it('keeps parent scope variables intact', async () => {
+        expect(await topscript(`
           let x = 1;
 
           function f() {
@@ -322,8 +397,8 @@ describe('topscript', () => {
         `)).toBe(1);
       });
 
-      it('updates parent scope variables when no local declaration exists', () => {
-        expect(topscript(`
+      it('updates parent scope variables when no local declaration exists', async () => {
+        expect(await topscript(`
           let x = 1;
 
           function f() {
@@ -335,8 +410,8 @@ describe('topscript', () => {
         )).toBe(2);
       });
 
-      it('creates proper closures', () => {
-        expect(topscript(`
+      it('creates proper closures', async () => {
+        expect(await topscript(`
           function createCounter() {
             let count = 0;
 
@@ -354,8 +429,8 @@ describe('topscript', () => {
         `)).toBe(2);
       });
 
-      it('supports nested function scopes', () => {
-        expect(topscript(`
+      it('supports nested function scopes', async () => {
+        expect(await topscript(`
           function outer() {
             let x = 1;
 
@@ -372,8 +447,8 @@ describe('topscript', () => {
         `)).toBe(3);
       });
 
-      it('maintains separate scopes for multiple closures', () => {
-        expect(topscript(`
+      it('maintains separate scopes for multiple closures', async () => {
+        expect(await topscript(`
           function createCounter(initial) {
             let count = initial;
 
@@ -393,8 +468,8 @@ describe('topscript', () => {
         `)).toEqual([2, 12]);
       });
 
-      it('correctly handles the arguments object', () => {
-        expect(topscript(`
+      it('correctly handles the arguments object', async () => {
+        expect(await topscript(`
           function sum() {
             let total = 0;
 
@@ -407,20 +482,20 @@ describe('topscript', () => {
         `)).toBe(4);
       });
 
-      it('correctly handles the delete operator', () => {
-        expect(topscript(`
+      it('correctly handles the delete operator', async () => {
+        expect(await topscript(`
           const obj = { a: 1, b: 2 };
           delete obj.a;
           obj
         `)).toEqual({ b: 2 });
 
-        expect(topscript(`
+        expect(await topscript(`
           const obj = { a: { b: 1, c: 2 } };
           delete obj.a.b;
           obj
         `)).toEqual({ a: { c: 2 } });
 
-        expect(topscript(`
+        expect(await topscript(`
           const arr = [1, 2, 3];
           delete arr[1];
           arr

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -138,6 +138,26 @@ describe('topscript', () => {
       expect(await topscript('`hello ${1 + 2}`')).toBe('hello 3');
       expect(await topscript('(() => `hello, ${"world"}`)()')).toBe('hello, world');
     });
+    
+    it('evaluates complex template literals correctly', async () => {
+      expect(await topscript('``')).toBe('');
+      expect(await topscript('`just text`')).toBe('just text');
+      expect(await topscript('`${1}${2}${3}`')).toBe('123');
+      expect(await topscript('`${1}${2}${3}suffix`')).toBe('123suffix');
+      expect(await topscript('`prefix${1}${2}${3}`')).toBe('prefix123');
+      expect(await topscript('`${`nested ${1 + 2}`}`')).toBe('nested 3');
+
+      expect(await topscript(`
+        function getWord() { return "dynamic"; }
+        \`This is a \${getWord()} template literal\`
+      `)).toBe('This is a dynamic template literal');
+
+      expect(await topscript(`
+        const obj = { name: "World" };
+        const arr = ["Hello"];
+        \`\${arr[0]}, \${obj.name}!\`
+      `)).toBe('Hello, World!');
+    });
 
     it('evaluates built-in member functions', async () => {
       expect(await topscript('"hello".length')).toBe(5);

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -268,10 +268,13 @@ describe('topscript', () => {
       await expect(() => topscript('const f = async () => {}')).rejects.toThrow('Async functions are not supported');
     });
     
-    it('throws when execution exceeds timeout', async () => {
-      await expect(() => 
-        topscript('while(true) {}', {}, { timeout: 100 })
-      ).rejects.toThrow('Execution timed out');
+    it('aborts execution when abort signal is triggered', async () => {
+      const controller = new AbortController();
+      const scriptPromise = topscript('while(true) {}', {}, { signal: controller.signal });
+      
+      setTimeout(() => controller.abort(), 100);
+      
+      await expect(scriptPromise).rejects.toThrow('Execution aborted');
     });
     
     it('evaluates while loops', async () => {

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import {
   Expression,
   Statement,
   TemplateLiteral,
+  WhileStatement,
 } from 'acorn';
 
 const ECMA_VERSION = 2019;
@@ -54,46 +55,76 @@ export function validate(script: string) {
   return parse(script, { ecmaVersion: ECMA_VERSION });
 }
 
-export function topscript(script: string, context: ObjectLiteral = {}): any {
-  function visitExpressionStatement({ node, scope }: { node: ExpressionStatement, scope: object }): object {
-    return visitNode({ node: node.expression, scope });
+async function immediate(): Promise<void> {
+  // This function allows us to run the code in the next tick of the event loop.
+  // This is important to make sure that the code is not blocking the event loop.
+
+  return new Promise((resolve) => {
+    if (typeof window !== 'undefined') {
+      setTimeout(() => resolve(), 0);
+      return;
+    }
+    
+    setImmediate(() => resolve());
+  });
+}
+
+export async function topscript(script: string, context: ObjectLiteral = {}, { timeout }: { timeout?: number } = {}): Promise<any> {
+  const abortSignal = timeout ? AbortSignal.timeout(timeout) : null;
+
+  function checkAbort() {
+    if (abortSignal && abortSignal.aborted) throw new Error('Execution timed out');
   }
 
-  function visitArrayExpression({ expression, scope }: { expression: ArrayExpression, scope: object }): any[] {
+  async function visitExpressionStatement({ node, scope }: { node: ExpressionStatement, scope: object }): Promise<object> {
+    return await visitNode({ node: node.expression, scope });
+  }
+
+  async function visitArrayExpression({ expression, scope }: { expression: ArrayExpression, scope: object }): Promise<any[]> {
     let res: any[] = [];
 
-    expression.elements.forEach((element) => {
+    for (const element of expression.elements) {
       if (element === null) {
         res.push(null);
-        return;
+        continue;
       }
 
       switch (element.type) {
         case 'SpreadElement':
-          res = [...res, ...visitNode({ node: element.argument, scope })];
-          return;
+          res = [...res, ...(await visitNode({ node: element.argument, scope }))];
+          break;
         default:
-          res.push(visitNode({ node: element, scope }));
-          return;
+          res.push(await visitNode({ node: element, scope }));
+          break;
       }
-    });
+    }
 
     return res;
   }
 
-  function visitObjectExpression({ expression, scope }: { expression: ObjectExpression, scope: object }): object {
+  async function mapSynchronous<T, U>(array: T[], fn: (item: T) => Promise<U>): Promise<U[]> {
+    const res: U[] = [];
+
+    for (const item of array) {
+      res.push(await fn(item));
+    }
+    
+    return res;
+  }
+
+  async function visitObjectExpression({ expression, scope }: { expression: ObjectExpression, scope: object }): Promise<object> {
     let res: ObjectLiteral = {};
 
-    expression.properties.forEach((property) => {
+    for (const property of expression.properties) {
       const type = property.type;
 
       switch (type) {
         case 'Property': {
-          const value = visitNode({ node: property.value, scope });
+          const value = await visitNode({ node: property.value, scope });
 
           if (property.computed) {
-            res[visitNode({ node: property.key, scope })] = value;
-            return;
+            res[await visitNode({ node: property.key, scope })] = value;
+            break;
           }
 
           if (property.key.type === 'Identifier') {
@@ -101,97 +132,99 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
           } else if (property.key.type === 'Literal') {
             if (typeof property.key.value !== 'string') throw new Error(`Unknown key type ${property.key.type}`);
             res[property.key.value] = value;
-            return;
+            break;
           } else {
             throw new Error(`Unknown key type ${property.key.type}`);
           }
 
           res[property.key.name] = value;
-          return;
+          break;
         };
         case 'SpreadElement':
-          res = { ...res, ...visitNode({ node: property.argument, scope }) };
-          return;
+          res = { ...res, ...(await visitNode({ node: property.argument, scope })) };
+          break;
         default:
           throw new Error(`Unknown property type ${type}`);
       }
-    });
+    }
 
     return res;
   }
 
-  function visitIfStatement({ node, scope }: { node: IfStatement, scope: object }) {
-    function visitConditionNode(conditionNode: Expression | Statement) {
+  async function visitIfStatement({ node, scope }: { node: IfStatement, scope: object }) {
+    async function visitConditionNode(conditionNode: Expression | Statement) {
       switch (conditionNode.type) {
-        case 'BlockStatement':
-          visitBlockStatement({ node: conditionNode, scope })();
+        case 'BlockStatement': {
+          const fn = visitBlockStatement({ node: conditionNode, scope });
+          await fn();
           return;
+        };
         default:
-          visitNode({ node: conditionNode, scope });
+          await visitNode({ node: conditionNode, scope });
           return;
       }
     }
 
-    if (visitNode({ node: node.test, scope })) {
-      visitConditionNode(node.consequent);
+    if (await visitNode({ node: node.test, scope })) {
+      await visitConditionNode(node.consequent);
       return;
     }
 
     if (node.alternate) {
-      visitConditionNode(node.alternate);
+      await visitConditionNode(node.alternate);
       return;
     }
   }
 
-  function visitBinaryExpression({ expression, scope }: { expression: BinaryExpression, scope: object }): any {
-    const left = () => visitNode({ node: expression.left, scope });
-    const right = () => visitNode({ node: expression.right, scope });
+  async function visitBinaryExpression({ expression, scope }: { expression: BinaryExpression, scope: object }): Promise<any> {
+    const left = async () => await visitNode({ node: expression.left, scope });
+    const right = async () => await visitNode({ node: expression.right, scope });
 
     switch (expression.operator) {
-      case '*': return left() * right();
-      case '/': return left() / right();
-      case '-': return left() - right();
-      case '+': return left() + right();
-      case '%': return left() % right();
-      case '**': return left() ** right();
-      case '^': return left() ^ right();
-      case '&': return left() & right();
-      case '|': return left() | right();
-      case '<': return left() < right();
-      case '<=': return left() <= right();
-      case '>': return left() > right();
-      case '>=': return left() >= right();
-      case '<<': return left() << right();
-      case '>>': return left() >> right();
-      case '==': return left() == right();
-      case '===': return left() === right();
-      case '!=': return left() != right();
-      case '!==': return left() !== right();
+      case '*': return (await left()) * (await right());
+      case '/': return (await left()) / (await right());
+      case '-': return (await left()) - (await right());
+      case '+': return (await left()) + (await right());
+      case '%': return (await left()) % (await right());
+      case '**': return (await left()) ** (await right());
+      case '^': return (await left()) ^ (await right());
+      case '&': return (await left()) & (await right());
+      case '|': return (await left()) | (await right());
+      case '<': return (await left()) < (await right());
+      case '<=': return (await left()) <= (await right());
+      case '>': return (await left()) > (await right());
+      case '>=': return (await left()) >= (await right());
+      case '<<': return (await left()) << (await right());
+      case '>>': return (await left()) >> (await right());
+      case '==': return (await left()) == (await right());
+      case '===': return (await left()) === await right();
+      case '!=': return (await left()) != await right();
+      case '!==': return (await left()) !== (await right());
       default: throw new Error(`Unknown binary operator ${expression.operator}`);
     }
   }
 
-  function visitLogicalExpression({ expression, scope }: { expression: LogicalExpression, scope: object }): any {
-    const left = () => visitNode({ node: expression.left, scope });
-    const right = () => visitNode({ node: expression.right, scope });
+  async function visitLogicalExpression({ expression, scope }: { expression: LogicalExpression, scope: object }): Promise<any> {
+    const left = async () => await visitNode({ node: expression.left, scope });
+    const right = async () => await visitNode({ node: expression.right, scope });
 
     switch (expression.operator) {
-      case '&&': return left() && right();
-      case '||': return left() || right();
+      case '&&': return (await left()) && (await right());
+      case '||': return (await left()) || (await right());
       default: throw new Error(`Unknown logical operator ${expression.operator}`);
     }
   }
 
-  function visitDelete({ node, scope }: { node: Expression, scope: object }) {
+  async function visitDelete({ node, scope }: { node: Expression, scope: object }) {
     switch (node.type) {
       case 'MemberExpression': {
-        const object = visitNode({ node: node.object, scope });
+        const object = await visitNode({ node: node.object, scope });
 
         if (node.property.type === 'Identifier') {
           delete object[node.property.name];
           return;
         } else {
-          delete object[visitNode({ node: node.property, scope })];
+          delete object[await visitNode({ node: node.property, scope })];
           return;
         }
       };
@@ -199,51 +232,93 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
     }
   }
 
-  function visitUnaryExpression({ expression, scope }: { expression: UnaryExpression, scope: object }): any {
+  async function visitUnaryExpression({ expression, scope }: { expression: UnaryExpression, scope: object }): Promise<any> {
     switch (expression.operator) {
-      case '-': return -visitNode({ node: expression.argument, scope });
-      case '+': return +visitNode({ node: expression.argument, scope });
-      case '!': return !visitNode({ node: expression.argument, scope });
-      case 'delete': return visitDelete({ node: expression.argument, scope });
+      case '-': return -(await visitNode({ node: expression.argument, scope }));
+      case '+': return +(await visitNode({ node: expression.argument, scope }));
+      case '!': return !(await visitNode({ node: expression.argument, scope }));
+      case 'delete': return await visitDelete({ node: expression.argument, scope });
       default:
         throw new Error(`Unknown unary operator ${expression.operator}`);
     }
   }
 
-  function visitAssignmentExpression({ expression, scope }: { expression: AssignmentExpression, scope: object }): any {
+  async function visitAssignmentExpression({ expression, scope }: { expression: AssignmentExpression, scope: object }): Promise<any> {
+    async function assignWithOperator(fn: (a: any, b: any) => any) {
+      if (expression.left.type === 'Identifier') {
+        if (!(expression.left.name in scope)) throw new Error(`${expression.left.name} is unknown`);
+        redefineProperty(scope, expression.left.name, { value: fn((scope as ObjectLiteral)[expression.left.name], await visitNode({ node: expression.right, scope })) });
+        return;
+      } else if (expression.left.type === 'MemberExpression') {
+        const object = await visitNode({ node: expression.left.object, scope });
+
+        if (expression.left.property.type === 'Identifier') {
+          object[expression.left.property.name] = fn(object[expression.left.property.name], await visitNode({ node: expression.right, scope }));
+          return;
+        } else {
+          object[await visitNode({ node: expression.left.property, scope })] = fn(
+            object[await visitNode({ node: expression.left.property, scope })],
+            await visitNode({ node: expression.right, scope })
+          );
+
+          return;
+        }
+      } else {
+        throw new Error(`Unknown left side of assignment ${expression.left.type}`);
+      }
+    }
+
     switch (expression.operator) {
       case '=':
-        if (expression.left.type === 'Identifier') {
-          if (!(expression.left.name in scope)) throw new Error(`${expression.left.name} is unknown`);
-          redefineProperty(scope, expression.left.name, { value: visitNode({ node: expression.right, scope }) });
-          return;
-        } else if (expression.left.type === 'MemberExpression') {
-          const object = visitNode({ node: expression.left.object, scope });
-
-          if (expression.left.property.type === 'Identifier') {
-            object[expression.left.property.name] = visitNode({ node: expression.right, scope });
-            return;
-          } else {
-            object[visitNode({ node: expression.left.property, scope })] = visitNode({ node: expression.right, scope });
-            return;
-          }
-        } else {
-          throw new Error(`Unknown left side of assignment ${expression.left.type}`);
-        }
+        await assignWithOperator((_a, b) => b);
+        return;
+      case '+=':
+        await assignWithOperator((a, b) => a + b);
+        return;
+      case '-=':
+        await assignWithOperator((a, b) => a - b);
+        return;
+      case '*=':
+        await assignWithOperator((a, b) => a * b);
+        return;
+      case '/=':
+        await assignWithOperator((a, b) => a / b);
+        return;
+      case '%=':
+        await assignWithOperator((a, b) => a % b);
+        return;
+      case '**=':
+        await assignWithOperator((a, b) => a ** b);
+        return;
+      case '^=':
+        await assignWithOperator((a, b) => a ^ b);
+        return;
+      case '&=':
+        await assignWithOperator((a, b) => a & b);
+        return;
+      case '|=':
+        await assignWithOperator((a, b) => a | b);
+        return;
+      case '<<=':
+        await assignWithOperator((a, b) => a << b);
+        return;
+      case '>>=':
+        await assignWithOperator((a, b) => a >> b);
+        return;
       default:
         throw new Error(`Unknown assignment operator ${expression.operator}`);
     }
   }
 
-  function visitCallExpression({ expression, scope }: { expression: CallExpression, scope: object }): any {
-    const args = expression.arguments.map((argument) => visitNode({ node: argument, scope }));
+  async function visitCallExpression({ expression, scope }: { expression: CallExpression, scope: object }): Promise<any> {
+    const args = await mapSynchronous(expression.arguments, async (argument) => await visitNode({ node: argument, scope }));
 
     switch (expression.callee.type) {
       case 'MemberExpression': {
         if(expression.callee.optional) throw new Error('Optional chaining is not supported');
 
-        const object = visitNode({ node: expression.callee.object, scope });
-        const fn = visitNode({ node: expression.callee.property, scope: object });
+        const object = await visitNode({ node: expression.callee.object, scope });
+        const fn = await visitNode({ node: expression.callee.property, scope: object });
 
         if (typeof fn !== 'function') throw new Error(`${fn} is not a function`);
 
@@ -256,11 +331,11 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
         return fn(...args);
       };
       case 'FunctionExpression': {
-        const fn = visitFunctionBody({ node: expression.callee.body, scope, params: expression.callee.params });
+        const fn = await visitFunctionBody({ node: expression.callee.body, scope, params: expression.callee.params });
         return fn(...args);
       };
       case 'ArrowFunctionExpression': {
-        const fn = visitArrowFunctionBody({ node: expression.callee.body, scope, params: expression.callee.params });
+        const fn = await visitArrowFunctionBody({ node: expression.callee.body, scope, params: expression.callee.params });
         return fn(...args);
       };
       default:
@@ -268,19 +343,21 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
     }
   }
 
-  function visitVariableDeclaration({ node, scope }: { node: VariableDeclaration, scope: object }) {
+  async function visitVariableDeclaration({ node, scope }: { node: VariableDeclaration, scope: object }) {
     for (const declaration of node.declarations) {
       switch (declaration.id.type) {
-        case 'Identifier':
+        case 'Identifier': {
           if (scope.hasOwnProperty(declaration.id.name)) throw new Error(`${declaration.id.name} is already declared`);
 
           if (declaration.init === null || declaration.init === undefined) {
             Object.defineProperty(scope, declaration.id.name, { value: declaration.init });
-            return;
+            break;
           }
 
-          Object.defineProperty(scope, declaration.id.name, { value: visitNode({ node: declaration.init, scope }), writable: node.kind !== 'const' });
-          return;
+          const value = await visitNode({ node: declaration.init, scope });
+          Object.defineProperty(scope, declaration.id.name, { value, writable: node.kind !== 'const' });
+          break;
+        };
         default:
           throw new Error(`Unknown variable declaration ${declaration.id.type}`);
       }
@@ -292,7 +369,10 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
   }
 
   function visitBlockStatement({ node, scope, params }: { node: BlockStatement, scope: object, params?: any[] }) {
-    return (...runtimeParams: any[]) => {
+    return async (...runtimeParams: any[]) => {
+      await immediate();
+      checkAbort();
+
       const newScope = createScope(scope);
       newScope['arguments'] = runtimeParams;
 
@@ -303,7 +383,7 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
       }
 
       try {
-        const res = node.body.map((item) => visitNode({ node: item, scope: newScope }));
+        const res = await mapSynchronous(node.body, async (item) => await visitNode({ node: item, scope: newScope }));
 
         return res[res.length - 1];
       } catch (error) {
@@ -315,14 +395,17 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
   }
 
   function visitArrowFunctionBody({ node, scope, params }: { node: AnyNode, scope: object, params: any[] }) {
-    return (...runtimeParams: any[]): any => {
+    return async (...runtimeParams: any[]): Promise<any> => {
+      await immediate();
+      checkAbort();
+
       const newScope = createScope(scope);
 
       params.forEach((param, index) => {
         visitParamNode({ node: param, scope: newScope, values: runtimeParams, index });
       });
 
-      return visitNode({ node, scope: newScope });
+      return await visitNode({ node, scope: newScope });
     };
   }
 
@@ -352,17 +435,17 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
     return visitFunctionBody({ node: node.body, scope, params: node.params });
   }
 
-  function visitReturnStatement({ node, scope }: { node: ReturnStatement, scope: object }) {
+  async function visitReturnStatement({ node, scope }: { node: ReturnStatement, scope: object }) {
     if (node.argument === undefined || node.argument === null) return node.argument;
 
-    return visitNode({ node: node.argument, scope });
+    return await visitNode({ node: node.argument, scope });
   }
 
-  function visitMemberExpression({ node, scope }: { node: MemberExpression, scope: object }): any {
-    const object = visitNode({ node: node.object, scope });
+  async function visitMemberExpression({ node, scope }: { node: MemberExpression, scope: object }): Promise<any> {
+    const object = await visitNode({ node: node.object, scope });
 
     if (node.computed) {
-      const property = visitNode({ node: node.property, scope });
+      const property = await visitNode({ node: node.property, scope });
       return object[property];
     }
 
@@ -388,48 +471,59 @@ export function topscript(script: string, context: ObjectLiteral = {}): any {
     }
   }
 
-  function visitTemplateLiteral({ node, scope }: { node: TemplateLiteral, scope: object }) {
+  async function visitTemplateLiteral({ node, scope }: { node: TemplateLiteral, scope: object }) {
     const quasis = node.quasis.map((quasi) => quasi.value.cooked);
-    const expressions = node.expressions.map((expression) => visitNode({ node: expression, scope }));
-
+    const expressions = await mapSynchronous(node.expressions, async (expression) => await visitNode({ node: expression, scope }));
+    
     return quasis.reduce((acc, cur, index) => {
       if (index === 0) return cur;
       return acc + expressions[index - 1] + cur;
     });
   }
 
-  function visitNode({ node, scope }: { node: AnyNode, scope: object }): any {
+  async function visitWhileStatement({ node, scope }: { node: WhileStatement, scope: object }) {
+    while (await visitNode({ node: node.test, scope })) {
+      await immediate();
+      checkAbort();
+
+      const fn = visitBlockStatement({ node: node.body as BlockStatement, scope });
+      await fn();
+    }
+  }
+
+  async function visitNode({ node, scope }: { node: AnyNode, scope: object }): Promise<any> {
     switch (node.type) {
-      case 'ExpressionStatement': return visitExpressionStatement({ node, scope });
-      case 'BinaryExpression': return visitBinaryExpression({ expression: node, scope });
-      case 'UnaryExpression': return visitUnaryExpression({ expression: node, scope });
-      case 'LogicalExpression': return visitLogicalExpression({ expression: node, scope });
+      case 'ExpressionStatement': return await visitExpressionStatement({ node, scope });
+      case 'BinaryExpression': return await visitBinaryExpression({ expression: node, scope });
+      case 'UnaryExpression': return await visitUnaryExpression({ expression: node, scope });
+      case 'LogicalExpression': return await visitLogicalExpression({ expression: node, scope });
       case 'Literal': return visitLiteral({ node });
       case 'Identifier':
         if (!hasProperty(scope, node.name)) throw new Error(`Unknown variable ${node.name}`);
 
         return (scope as ObjectLiteral)[node.name];
-      case 'VariableDeclaration': return visitVariableDeclaration({ node, scope });
+      case 'VariableDeclaration': return await visitVariableDeclaration({ node, scope });
       case 'FunctionExpression': return visitFunctionExpression({ node, scope });
       case 'FunctionDeclaration': return visitFunctionDeclaration({ node, scope });
       case 'ArrowFunctionExpression': return visitArrowFunctionExpression({ node, scope });
       case 'EmptyStatement': return;
-      case 'ReturnStatement': throw new ReturnException(visitReturnStatement({ node, scope }));
-      case 'CallExpression': return visitCallExpression({ expression: node, scope });
-      case 'AssignmentExpression': return visitAssignmentExpression({ expression: node, scope });
-      case 'ArrayExpression': return visitArrayExpression({ expression: node, scope });
-      case 'ObjectExpression': return visitObjectExpression({ expression: node, scope });
-      case 'IfStatement': return visitIfStatement({ node, scope });
+      case 'ReturnStatement': throw new ReturnException(await visitReturnStatement({ node, scope }));
+      case 'CallExpression': return await visitCallExpression({ expression: node, scope });
+      case 'AssignmentExpression': return await visitAssignmentExpression({ expression: node, scope });
+      case 'ArrayExpression': return await visitArrayExpression({ expression: node, scope });
+      case 'ObjectExpression': return await visitObjectExpression({ expression: node, scope });
+      case 'IfStatement': return await visitIfStatement({ node, scope });
       case 'BlockStatement': return visitBlockStatement({ node, scope })();
-      case 'MemberExpression': return visitMemberExpression({ node, scope });
-      case 'TemplateLiteral': return visitTemplateLiteral({ node, scope });
+      case 'MemberExpression': return await visitMemberExpression({ node, scope });
+      case 'TemplateLiteral': return await visitTemplateLiteral({ node, scope });
+      case 'WhileStatement': return await visitWhileStatement({ node, scope });
       default: throw new Error(`Unknown node type ${node.type}`);
     };
   }
 
   const tree = parse(script, { ecmaVersion: ECMA_VERSION }).body;
   const scope = createScope(context);
-  const res = tree.map((node: AnyNode) => visitNode({ node, scope }));
+  const res = await mapSynchronous(tree, async (node) => await visitNode({ node, scope }));
 
   return res[res.length - 1];
 }

--- a/index.ts
+++ b/index.ts
@@ -100,7 +100,7 @@ export async function topscript(script: string, context: ObjectLiteral = {}, { s
     return res;
   }
 
-  async function mapSynchronous<T, U>(array: T[], fn: (item: T) => Promise<U>): Promise<U[]> {
+  async function mapAsync<T, U>(array: T[], fn: (item: T) => Promise<U>): Promise<U[]> {
     const res: U[] = [];
 
     for (const item of array) {
@@ -307,7 +307,7 @@ export async function topscript(script: string, context: ObjectLiteral = {}, { s
   }
 
   async function visitCallExpression({ expression, scope }: { expression: CallExpression, scope: object }): Promise<any> {
-    const args = await mapSynchronous(expression.arguments, async (argument) => await visitNode({ node: argument, scope }));
+    const args = await mapAsync(expression.arguments, async (argument) => await visitNode({ node: argument, scope }));
 
     switch (expression.callee.type) {
       case 'MemberExpression': {
@@ -379,7 +379,7 @@ export async function topscript(script: string, context: ObjectLiteral = {}, { s
       }
 
       try {
-        const res = await mapSynchronous(node.body, async (item) => await visitNode({ node: item, scope: newScope }));
+        const res = await mapAsync(node.body, async (item) => await visitNode({ node: item, scope: newScope }));
 
         return res[res.length - 1];
       } catch (error) {
@@ -469,7 +469,7 @@ export async function topscript(script: string, context: ObjectLiteral = {}, { s
 
   async function visitTemplateLiteral({ node, scope }: { node: TemplateLiteral, scope: object }) {
     const quasis = node.quasis.map((quasi) => quasi.value.cooked);
-    const expressions = await mapSynchronous(node.expressions, async (expression) => await visitNode({ node: expression, scope }));
+    const expressions = await mapAsync(node.expressions, async (expression) => await visitNode({ node: expression, scope }));
     
     const result = quasis[0] || '';
 
@@ -520,7 +520,7 @@ export async function topscript(script: string, context: ObjectLiteral = {}, { s
 
   const tree = parse(script, { ecmaVersion: ECMA_VERSION }).body;
   const scope = createScope(context);
-  const res = await mapSynchronous(tree, async (node) => await visitNode({ node, scope }));
+  const res = await mapAsync(tree, async (node) => await visitNode({ node, scope }));
 
   return res[res.length - 1];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topscript",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Adds the option to pass a abort signal to stop the execution. To support this, topscript must be changed to return a promise and in function calls as well as while loops we check the signal. Further, in function calls and while loops we use setImmediate/setTimeout to pass control to the event loop to make it possible to interrupt the execution.